### PR TITLE
feat: add feed gateway client example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     compile group: 'org.quickfixj', name: 'quickfixj-messages-fix44', version: '2.1.+'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.+'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.7.+'
+    // required for websocket examples
+    implementation 'org.glassfish.tyrus.bundles:tyrus-standalone-client-jdk:1.16'
+
     testCompile group: 'junit', name: 'junit', version: '4.+'
 }
 

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -20,4 +20,5 @@
         "https://checkstyle.org/dtds/suppressions_1_0.dtd">
 <suppressions>
     <suppress checks="." files="com[\\/]reactivemarkets[\\/]encoding[\\/]fbs[\\/]*"/>
+    <suppress checks="." files="com[\\/]reactivemarkets[\\/]encoding[\\/]feed[\\/]*"/>
 </suppressions>

--- a/src/main/java/com/reactivemarkets/encoding/feed/Body.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/Body.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+public final class Body {
+  private Body() { }
+  public static final byte NONE = 0;
+  public static final byte FeedRequest = 1;
+  public static final byte FeedRequestReject = 2;
+  public static final byte MDSnapshotL2 = 3;
+  public static final byte PublicTrade = 4;
+  public static final byte SessionStatus = 5;
+
+  public static final String[] names = { "NONE", "FeedRequest", "FeedRequestReject", "MDSnapshotL2", "PublicTrade", "SessionStatus", };
+
+  public static String name(int e) { return names[e]; }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/Feed.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/Feed.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+public final class Feed {
+  private Feed() { }
+  public static final short Default = 0;
+
+  public static final String[] names = { "Default", };
+
+  public static String name(int e) { return names[e]; }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/FeedRequest.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/FeedRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class FeedRequest extends Table {
+  public static FeedRequest getRootAsFeedRequest(ByteBuffer _bb) { return getRootAsFeedRequest(_bb, new FeedRequest()); }
+  public static FeedRequest getRootAsFeedRequest(ByteBuffer _bb, FeedRequest obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
+  public FeedRequest __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public String reqId() { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer reqIdAsByteBuffer() { return __vector_as_bytebuffer(4, 1); }
+  public ByteBuffer reqIdInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
+  public short subReqType() { int o = __offset(6); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
+  public short feed() { int o = __offset(8); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
+  public int grouping() { int o = __offset(10); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public int conflation() { int o = __offset(12); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public short depth() { int o = __offset(14); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
+  public String markets(int j) { int o = __offset(16); return o != 0 ? __string(__vector(o) + j * 4) : null; }
+  public int marketsLength() { int o = __offset(16); return o != 0 ? __vector_len(o) : 0; }
+
+  public static int createFeedRequest(FlatBufferBuilder builder,
+      int req_idOffset,
+      short sub_req_type,
+      short feed,
+      int grouping,
+      int conflation,
+      short depth,
+      int marketsOffset) {
+    builder.startObject(7);
+    FeedRequest.addMarkets(builder, marketsOffset);
+    FeedRequest.addConflation(builder, conflation);
+    FeedRequest.addGrouping(builder, grouping);
+    FeedRequest.addReqId(builder, req_idOffset);
+    FeedRequest.addDepth(builder, depth);
+    FeedRequest.addFeed(builder, feed);
+    FeedRequest.addSubReqType(builder, sub_req_type);
+    return FeedRequest.endFeedRequest(builder);
+  }
+
+  public static void startFeedRequest(FlatBufferBuilder builder) { builder.startObject(7); }
+  public static void addReqId(FlatBufferBuilder builder, int reqIdOffset) { builder.addOffset(0, reqIdOffset, 0); }
+  public static void addSubReqType(FlatBufferBuilder builder, short subReqType) { builder.addShort(1, subReqType, 1); }
+  public static void addFeed(FlatBufferBuilder builder, short feed) { builder.addShort(2, feed, 0); }
+  public static void addGrouping(FlatBufferBuilder builder, int grouping) { builder.addInt(3, grouping, 0); }
+  public static void addConflation(FlatBufferBuilder builder, int conflation) { builder.addInt(4, conflation, 0); }
+  public static void addDepth(FlatBufferBuilder builder, short depth) { builder.addShort(5, depth, 0); }
+  public static void addMarkets(FlatBufferBuilder builder, int marketsOffset) { builder.addOffset(6, marketsOffset, 0); }
+  public static int createMarketsVector(FlatBufferBuilder builder, int[] data) { builder.startVector(4, data.length, 4); for (int i = data.length - 1; i >= 0; i--) builder.addOffset(data[i]); return builder.endVector(); }
+  public static void startMarketsVector(FlatBufferBuilder builder, int numElems) { builder.startVector(4, numElems, 4); }
+  public static int endFeedRequest(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    return o;
+  }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/FeedRequestReject.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/FeedRequestReject.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class FeedRequestReject extends Table {
+  public static FeedRequestReject getRootAsFeedRequestReject(ByteBuffer _bb) { return getRootAsFeedRequestReject(_bb, new FeedRequestReject()); }
+  public static FeedRequestReject getRootAsFeedRequestReject(ByteBuffer _bb, FeedRequestReject obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
+  public FeedRequestReject __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public String reqId() { int o = __offset(4); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer reqIdAsByteBuffer() { return __vector_as_bytebuffer(4, 1); }
+  public ByteBuffer reqIdInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
+  public int errorCode() { int o = __offset(6); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public String errorMessage() { int o = __offset(8); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer errorMessageAsByteBuffer() { return __vector_as_bytebuffer(8, 1); }
+  public ByteBuffer errorMessageInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 8, 1); }
+
+  public static int createFeedRequestReject(FlatBufferBuilder builder,
+      int req_idOffset,
+      int error_code,
+      int error_messageOffset) {
+    builder.startObject(3);
+    FeedRequestReject.addErrorMessage(builder, error_messageOffset);
+    FeedRequestReject.addErrorCode(builder, error_code);
+    FeedRequestReject.addReqId(builder, req_idOffset);
+    return FeedRequestReject.endFeedRequestReject(builder);
+  }
+
+  public static void startFeedRequestReject(FlatBufferBuilder builder) { builder.startObject(3); }
+  public static void addReqId(FlatBufferBuilder builder, int reqIdOffset) { builder.addOffset(0, reqIdOffset, 0); }
+  public static void addErrorCode(FlatBufferBuilder builder, int errorCode) { builder.addInt(1, errorCode, 0); }
+  public static void addErrorMessage(FlatBufferBuilder builder, int errorMessageOffset) { builder.addOffset(2, errorMessageOffset, 0); }
+  public static int endFeedRequestReject(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    return o;
+  }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/MDLevel2.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/MDLevel2.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class MDLevel2 extends Struct {
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; }
+  public MDLevel2 __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public double qty() { return bb.getDouble(bb_pos + 0); }
+  public double price() { return bb.getDouble(bb_pos + 8); }
+
+  public static int createMDLevel2(FlatBufferBuilder builder, double qty, double price) {
+    builder.prep(8, 16);
+    builder.putDouble(price);
+    builder.putDouble(qty);
+    return builder.offset();
+  }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/MDSnapshotL2.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/MDSnapshotL2.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class MDSnapshotL2 extends Table {
+  public static MDSnapshotL2 getRootAsMDSnapshotL2(ByteBuffer _bb) { return getRootAsMDSnapshotL2(_bb, new MDSnapshotL2()); }
+  public static MDSnapshotL2 getRootAsMDSnapshotL2(ByteBuffer _bb, MDSnapshotL2 obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
+  public MDSnapshotL2 __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public long sourceTs() { int o = __offset(4); return o != 0 ? bb.getLong(o + bb_pos) : 0L; }
+  public String source() { int o = __offset(6); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer sourceAsByteBuffer() { return __vector_as_bytebuffer(6, 1); }
+  public ByteBuffer sourceInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 6, 1); }
+  public String market() { int o = __offset(8); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer marketAsByteBuffer() { return __vector_as_bytebuffer(8, 1); }
+  public ByteBuffer marketInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 8, 1); }
+  public long id() { int o = __offset(10); return o != 0 ? bb.getLong(o + bb_pos) : 0L; }
+  public int flags() { int o = __offset(12); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
+  public MDLevel2 bidSide(int j) { return bidSide(new MDLevel2(), j); }
+  public MDLevel2 bidSide(MDLevel2 obj, int j) { int o = __offset(14); return o != 0 ? obj.__assign(__vector(o) + j * 16, bb) : null; }
+  public int bidSideLength() { int o = __offset(14); return o != 0 ? __vector_len(o) : 0; }
+  public MDLevel2 offerSide(int j) { return offerSide(new MDLevel2(), j); }
+  public MDLevel2 offerSide(MDLevel2 obj, int j) { int o = __offset(16); return o != 0 ? obj.__assign(__vector(o) + j * 16, bb) : null; }
+  public int offerSideLength() { int o = __offset(16); return o != 0 ? __vector_len(o) : 0; }
+
+  public static int createMDSnapshotL2(FlatBufferBuilder builder,
+      long source_ts,
+      int sourceOffset,
+      int marketOffset,
+      long id,
+      int flags,
+      int bid_sideOffset,
+      int offer_sideOffset) {
+    builder.startObject(7);
+    MDSnapshotL2.addId(builder, id);
+    MDSnapshotL2.addSourceTs(builder, source_ts);
+    MDSnapshotL2.addOfferSide(builder, offer_sideOffset);
+    MDSnapshotL2.addBidSide(builder, bid_sideOffset);
+    MDSnapshotL2.addMarket(builder, marketOffset);
+    MDSnapshotL2.addSource(builder, sourceOffset);
+    MDSnapshotL2.addFlags(builder, flags);
+    return MDSnapshotL2.endMDSnapshotL2(builder);
+  }
+
+  public static void startMDSnapshotL2(FlatBufferBuilder builder) { builder.startObject(7); }
+  public static void addSourceTs(FlatBufferBuilder builder, long sourceTs) { builder.addLong(0, sourceTs, 0L); }
+  public static void addSource(FlatBufferBuilder builder, int sourceOffset) { builder.addOffset(1, sourceOffset, 0); }
+  public static void addMarket(FlatBufferBuilder builder, int marketOffset) { builder.addOffset(2, marketOffset, 0); }
+  public static void addId(FlatBufferBuilder builder, long id) { builder.addLong(3, id, 0L); }
+  public static void addFlags(FlatBufferBuilder builder, int flags) { builder.addShort(4, (short)flags, (short)0); }
+  public static void addBidSide(FlatBufferBuilder builder, int bidSideOffset) { builder.addOffset(5, bidSideOffset, 0); }
+  public static void startBidSideVector(FlatBufferBuilder builder, int numElems) { builder.startVector(16, numElems, 8); }
+  public static void addOfferSide(FlatBufferBuilder builder, int offerSideOffset) { builder.addOffset(6, offerSideOffset, 0); }
+  public static void startOfferSideVector(FlatBufferBuilder builder, int numElems) { builder.startVector(16, numElems, 8); }
+  public static int endMDSnapshotL2(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    builder.required(o, 8);  // market
+    return o;
+  }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/Message.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/Message.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class Message extends Table {
+  public static Message getRootAsMessage(ByteBuffer _bb) { return getRootAsMessage(_bb, new Message()); }
+  public static Message getRootAsMessage(ByteBuffer _bb, Message obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public static boolean MessageBufferHasIdentifier(ByteBuffer _bb) { return __has_identifier(_bb, "RMF1"); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
+  public Message __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public long tts() { int o = __offset(4); return o != 0 ? bb.getLong(o + bb_pos) : 0L; }
+  public byte bodyType() { int o = __offset(6); return o != 0 ? bb.get(o + bb_pos) : 0; }
+  public Table body(Table obj) { int o = __offset(8); return o != 0 ? __union(obj, o) : null; }
+
+  public static int createMessage(FlatBufferBuilder builder,
+      long tts,
+      byte body_type,
+      int bodyOffset) {
+    builder.startObject(3);
+    Message.addTts(builder, tts);
+    Message.addBody(builder, bodyOffset);
+    Message.addBodyType(builder, body_type);
+    return Message.endMessage(builder);
+  }
+
+  public static void startMessage(FlatBufferBuilder builder) { builder.startObject(3); }
+  public static void addTts(FlatBufferBuilder builder, long tts) { builder.addLong(0, tts, 0L); }
+  public static void addBodyType(FlatBufferBuilder builder, byte bodyType) { builder.addByte(1, bodyType, 0); }
+  public static void addBody(FlatBufferBuilder builder, int bodyOffset) { builder.addOffset(2, bodyOffset, 0); }
+  public static int endMessage(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    return o;
+  }
+  public static void finishMessageBuffer(FlatBufferBuilder builder, int offset) { builder.finish(offset, "RMF1"); }
+  public static void finishSizePrefixedMessageBuffer(FlatBufferBuilder builder, int offset) { builder.finishSizePrefixed(offset, "RMF1"); }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/PublicTrade.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/PublicTrade.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class PublicTrade extends Table {
+  public static PublicTrade getRootAsPublicTrade(ByteBuffer _bb) { return getRootAsPublicTrade(_bb, new PublicTrade()); }
+  public static PublicTrade getRootAsPublicTrade(ByteBuffer _bb, PublicTrade obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
+  public PublicTrade __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public long sourceTs() { int o = __offset(4); return o != 0 ? bb.getLong(o + bb_pos) : 0L; }
+  public String source() { int o = __offset(6); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer sourceAsByteBuffer() { return __vector_as_bytebuffer(6, 1); }
+  public ByteBuffer sourceInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 6, 1); }
+  public String market() { int o = __offset(8); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer marketAsByteBuffer() { return __vector_as_bytebuffer(8, 1); }
+  public ByteBuffer marketInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 8, 1); }
+  public String id() { int o = __offset(10); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer idAsByteBuffer() { return __vector_as_bytebuffer(10, 1); }
+  public ByteBuffer idInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 10, 1); }
+  public short side() { int o = __offset(12); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
+  public double qty() { int o = __offset(14); return o != 0 ? bb.getDouble(o + bb_pos) : 0.0; }
+  public double price() { int o = __offset(16); return o != 0 ? bb.getDouble(o + bb_pos) : 0.0; }
+  public String execVenue() { int o = __offset(18); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer execVenueAsByteBuffer() { return __vector_as_bytebuffer(18, 1); }
+  public ByteBuffer execVenueInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 18, 1); }
+
+  public static int createPublicTrade(FlatBufferBuilder builder,
+      long source_ts,
+      int sourceOffset,
+      int marketOffset,
+      int idOffset,
+      short side,
+      double qty,
+      double price,
+      int exec_venueOffset) {
+    builder.startObject(8);
+    PublicTrade.addPrice(builder, price);
+    PublicTrade.addQty(builder, qty);
+    PublicTrade.addSourceTs(builder, source_ts);
+    PublicTrade.addExecVenue(builder, exec_venueOffset);
+    PublicTrade.addId(builder, idOffset);
+    PublicTrade.addMarket(builder, marketOffset);
+    PublicTrade.addSource(builder, sourceOffset);
+    PublicTrade.addSide(builder, side);
+    return PublicTrade.endPublicTrade(builder);
+  }
+
+  public static void startPublicTrade(FlatBufferBuilder builder) { builder.startObject(8); }
+  public static void addSourceTs(FlatBufferBuilder builder, long sourceTs) { builder.addLong(0, sourceTs, 0L); }
+  public static void addSource(FlatBufferBuilder builder, int sourceOffset) { builder.addOffset(1, sourceOffset, 0); }
+  public static void addMarket(FlatBufferBuilder builder, int marketOffset) { builder.addOffset(2, marketOffset, 0); }
+  public static void addId(FlatBufferBuilder builder, int idOffset) { builder.addOffset(3, idOffset, 0); }
+  public static void addSide(FlatBufferBuilder builder, short side) { builder.addShort(4, side, 0); }
+  public static void addQty(FlatBufferBuilder builder, double qty) { builder.addDouble(5, qty, 0.0); }
+  public static void addPrice(FlatBufferBuilder builder, double price) { builder.addDouble(6, price, 0.0); }
+  public static void addExecVenue(FlatBufferBuilder builder, int execVenueOffset) { builder.addOffset(7, execVenueOffset, 0); }
+  public static int endPublicTrade(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    builder.required(o, 8);  // market
+    return o;
+  }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/SessionStatus.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/SessionStatus.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+import java.nio.*;
+import java.util.*;
+import com.google.flatbuffers.*;
+
+@SuppressWarnings("unused")
+public final class SessionStatus extends Table {
+  public static SessionStatus getRootAsSessionStatus(ByteBuffer _bb) { return getRootAsSessionStatus(_bb, new SessionStatus()); }
+  public static SessionStatus getRootAsSessionStatus(ByteBuffer _bb, SessionStatus obj) { _bb.order(ByteOrder.LITTLE_ENDIAN); return (obj.__assign(_bb.getInt(_bb.position()) + _bb.position(), _bb)); }
+  public void __init(int _i, ByteBuffer _bb) { bb_pos = _i; bb = _bb; vtable_start = bb_pos - bb.getInt(bb_pos); vtable_size = bb.getShort(vtable_start); }
+  public SessionStatus __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
+
+  public long sourceTs() { int o = __offset(4); return o != 0 ? bb.getLong(o + bb_pos) : 0L; }
+  public String source() { int o = __offset(6); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer sourceAsByteBuffer() { return __vector_as_bytebuffer(6, 1); }
+  public ByteBuffer sourceInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 6, 1); }
+  public int code() { int o = __offset(8); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public String message() { int o = __offset(10); return o != 0 ? __string(o + bb_pos) : null; }
+  public ByteBuffer messageAsByteBuffer() { return __vector_as_bytebuffer(10, 1); }
+  public ByteBuffer messageInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 10, 1); }
+
+  public static int createSessionStatus(FlatBufferBuilder builder,
+      long source_ts,
+      int sourceOffset,
+      int code,
+      int messageOffset) {
+    builder.startObject(4);
+    SessionStatus.addSourceTs(builder, source_ts);
+    SessionStatus.addMessage(builder, messageOffset);
+    SessionStatus.addCode(builder, code);
+    SessionStatus.addSource(builder, sourceOffset);
+    return SessionStatus.endSessionStatus(builder);
+  }
+
+  public static void startSessionStatus(FlatBufferBuilder builder) { builder.startObject(4); }
+  public static void addSourceTs(FlatBufferBuilder builder, long sourceTs) { builder.addLong(0, sourceTs, 0L); }
+  public static void addSource(FlatBufferBuilder builder, int sourceOffset) { builder.addOffset(1, sourceOffset, 0); }
+  public static void addCode(FlatBufferBuilder builder, int code) { builder.addInt(2, code, 0); }
+  public static void addMessage(FlatBufferBuilder builder, int messageOffset) { builder.addOffset(3, messageOffset, 0); }
+  public static int endSessionStatus(FlatBufferBuilder builder) {
+    int o = builder.endObject();
+    return o;
+  }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/Side.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/Side.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+public final class Side {
+  private Side() { }
+  public static final short Sell = -1;
+  public static final short None = 0;
+  public static final short Buy = 1;
+
+  public static final String[] names = { "Sell", "None", "Buy", };
+
+  public static String name(int e) { return names[e - Sell]; }
+}

--- a/src/main/java/com/reactivemarkets/encoding/feed/SubReqType.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/SubReqType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.encoding.feed;
+
+public final class SubReqType {
+  private SubReqType() { }
+  public static final short Subscribe = 1;
+  public static final short Unsubscribe = 2;
+
+  public static final String[] names = { "Subscribe", "Unsubscribe", };
+
+  public static String name(int e) { return names[e - Subscribe]; }
+}

--- a/src/main/java/com/reactivemarkets/platform/example/feed/FeedGatewayL2Subscription.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/FeedGatewayL2Subscription.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.example.feed;
+
+import static com.reactivemarkets.platform.ws.tyrus.TyrusWebSocketClientFactory.newWebSocketClient;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.websocket.MessageHandler.Whole;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.reactivemarkets.platform.util.LoggerUtil;
+import com.reactivemarkets.platform.ws.FeedGatewayException;
+import com.reactivemarkets.platform.ws.FeedRequestMessageFactory;
+import com.reactivemarkets.platform.ws.FeedRequestParameters;
+import com.reactivemarkets.platform.ws.tyrus.TyrusWebSocketClient;
+
+public final class FeedGatewayL2Subscription {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FeedGatewayL2Subscription.class);
+    private static final String LIVE_URI = "wss://api.platform.reactivemarkets.com/feed";
+    // Authentication token is generated from the platform UI in the keys section
+    private static final String AUTH_TOKEN = "<insert your token here or use the FEED_GATEWAY_TOKEN environment variable>";
+
+    private FeedGatewayL2Subscription() {
+    }
+
+    public static void main(final String[] args) {
+
+        LoggerUtil.consoleLogger();
+
+        // load the uri and auth token from either environment variables or updated
+        // constants
+        final Map<String, String> env = System.getenv();
+        final String uri = env.getOrDefault("FEED_GATEWAY_URI", LIVE_URI);
+        final String authToken = env.getOrDefault("FEED_GATEWAY_TOKEN", AUTH_TOKEN);
+
+        // create a listener that will log the first 10 messages.
+        final CountDownLatch latch = new CountDownLatch(10);
+        final FeedListener listener = newCountdownListener(latch);
+        final Whole<ByteBuffer> handler = new FeedMessageHandler(listener);
+
+        TyrusWebSocketClient client = null;
+        try {
+            client = newWebSocketClient(uri, authToken, handler);
+            // blocking connect to the websocket
+            client.connect();
+            // create a new request with default settings for conflation, depth and grouping
+            final FeedRequestParameters request = new FeedRequestParameters(UUID.randomUUID().toString(), "BTCUSD-CNB");
+            final ByteBuffer buffer = FeedRequestMessageFactory.newSubscription(request);
+
+            client.send(buffer);
+            // wait for the data countdown to complete or timeout after 15 seconds
+            if (latch.await(15, TimeUnit.SECONDS)) {
+                LOGGER.info("Example completed successfully");
+            }
+        } catch (FeedGatewayException ex) {
+            LOGGER.error("Error connecting to feed websocket.", ex);
+        } catch (InterruptedException e) {
+            LOGGER.error("Error whilst waiting for data.", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            if (client != null) {
+                try {
+                    client.close();
+                } catch (Exception e) {
+                }
+            }
+        }
+    }
+
+    private static FeedListener newCountdownListener(final CountDownLatch latch) {
+        return l2Update -> {
+            LOGGER.info("{}", l2Update);
+            latch.countDown();
+        };
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/example/feed/FeedListener.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/FeedListener.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.example.feed;
+
+public interface FeedListener {
+
+    void onMarketDepth(MarketDepth depth);
+
+    default void onFeedRequestReject(RequestReject reject) {
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/example/feed/FeedMessageHandler.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/FeedMessageHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.example.feed;
+
+import java.nio.ByteBuffer;
+
+import javax.websocket.MessageHandler;
+
+import com.reactivemarkets.encoding.feed.Body;
+import com.reactivemarkets.encoding.feed.FeedRequestReject;
+import com.reactivemarkets.encoding.feed.MDLevel2;
+import com.reactivemarkets.encoding.feed.MDSnapshotL2;
+import com.reactivemarkets.encoding.feed.Message;
+
+public class FeedMessageHandler implements MessageHandler.Whole<ByteBuffer> {
+
+    private final FeedListener callbackHandler;
+    private static final ThreadLocal<Message> LOCAL_MESSAGE = ThreadLocal.withInitial(Message::new);
+    private static final ThreadLocal<MDSnapshotL2> LOCAL_L2_SNAPSHOT = ThreadLocal.withInitial(MDSnapshotL2::new);
+    private static final ThreadLocal<MDLevel2> LOCAL_MDLEVEL = ThreadLocal.withInitial(MDLevel2::new);
+    private static final ThreadLocal<FeedRequestReject> LOCAL_REQUEST_REJECT = ThreadLocal
+            .withInitial(FeedRequestReject::new);
+
+    public FeedMessageHandler(final FeedListener mdListener) {
+        this.callbackHandler = mdListener;
+    }
+
+    public void onMessage(final ByteBuffer buf) {
+        final Message msg = LOCAL_MESSAGE.get();
+        Message.getRootAsMessage(buf, msg);
+        final long timestamp = msg.tts();
+
+        switch (msg.bodyType()) {
+        case Body.MDSnapshotL2:
+            final MDSnapshotL2 ss = LOCAL_L2_SNAPSHOT.get();
+            msg.body(ss);
+            onLevel2Snapshot(timestamp, ss);
+            break;
+        case Body.FeedRequestReject:
+            final FeedRequestReject reqRej = LOCAL_REQUEST_REJECT.get();
+            msg.body(reqRej);
+            onRejectedRequest(timestamp, reqRej);
+            break;
+        default:
+            throw new IllegalStateException("Unexpected message type.");
+        }
+    }
+
+    private void onLevel2Snapshot(final long timestamp, final MDSnapshotL2 ss) {
+        final MarketDepth depth = new MarketDepth();
+        depth.setId(ss.id());
+        depth.setSource(ss.source());
+        depth.setFlags(ss.flags());
+        depth.setBidCount(ss.bidSideLength());
+        depth.setOfferCount(ss.offerSideLength());
+        depth.setTimestamp(timestamp);
+        depth.setSourceTimestamp(ss.sourceTs());
+        depth.setSymbol(ss.market());
+
+        final MDLevel2 l2 = LOCAL_MDLEVEL.get();
+        for (int i = 0; i < ss.bidSideLength(); i++) {
+            ss.bidSide(l2, i);
+            depth.setBidQty(l2.qty(), i);
+            depth.setBidPrice(l2.price(), i);
+        }
+
+        for (int i = 0; i < ss.offerSideLength(); i++) {
+            ss.offerSide(l2, i);
+            depth.setOfferQty(l2.qty(), i);
+            depth.setOfferPrice(l2.price(), i);
+        }
+
+        callbackHandler.onMarketDepth(depth);
+    }
+
+    private void onRejectedRequest(final long timestamp, final FeedRequestReject reqRej) {
+        RequestReject reject = new RequestReject();
+        reject.setTimestamp(timestamp);
+        reject.setRequestId(reqRej.reqId());
+        reject.setErrorCode(reqRej.errorCode());
+        reject.setErrorMessage(reqRej.errorMessage());
+        callbackHandler.onFeedRequestReject(reject);
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/example/feed/MarketDepth.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/MarketDepth.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.example.feed;
+
+import java.util.Arrays;
+
+public class MarketDepth {
+
+    private long id;
+    private long flags;
+    private long timestamp;
+    private long sourceTimestamp;
+    private String symbol;
+    private String source;
+    private int bidCount;
+    private int offerCount;
+    private double[] bidPrice;
+    private double[] bidQty;
+    private double[] offerPrice;
+    private double[] offerQty;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(final long id) {
+        this.id = id;
+    }
+
+    public long getFlags() {
+        return flags;
+    }
+
+    public void setFlags(final long flags) {
+        this.flags = flags;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(final long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(final String symbol) {
+        this.symbol = symbol;
+    }
+
+    public int getBidCount() {
+        return bidCount;
+    }
+
+    public void setBidCount(final int bidCount) {
+        this.bidCount = bidCount;
+    }
+
+    public int getOfferCount() {
+        return offerCount;
+    }
+
+    public void setOfferCount(final int offerCount) {
+        this.offerCount = offerCount;
+    }
+
+    public double[] getBidPrice() {
+        return bidPrice;
+    }
+
+    public void setBidPrice(final double[] bidPrice) {
+        this.bidPrice = bidPrice;
+    }
+
+    public double[] getBidQty() {
+        return bidQty;
+    }
+
+    public void setBidQty(final double[] bidQty) {
+        this.bidQty = bidQty;
+    }
+
+    public double[] getOfferPrice() {
+        return offerPrice;
+    }
+
+    public void setOfferPrice(final double[] offerPrice) {
+        this.offerPrice = offerPrice;
+    }
+
+    public double[] getOfferQty() {
+        return offerQty;
+    }
+
+    public void setOfferQty(final double[] offerQty) {
+        this.offerQty = offerQty;
+    }
+
+    public void setOfferQty(final double offerQty, final int i) {
+        this.offerQty[i] = offerQty;
+    }
+
+    public void setOfferPrice(final double offerPrice, final int i) {
+        this.offerPrice[i] = offerPrice;
+    }
+
+    public void setBidQty(final double bidQty, final int i) {
+        this.bidQty[i] = bidQty;
+    }
+
+    public void setBidPrice(final double bidPrice, final int i) {
+        this.bidPrice[i] = bidPrice;
+    }
+
+    public long getSourceTimestamp() {
+        return sourceTimestamp;
+    }
+
+    public void setSourceTimestamp(final long sourceTimestamp) {
+        this.sourceTimestamp = sourceTimestamp;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(final String source) {
+        this.source = source;
+    }
+
+    @Override
+    public String toString() {
+        return "MarketDepth [id=" + id + ", flags=" + flags + ", timestamp=" + timestamp + ", sourceTimestamp="
+                + sourceTimestamp + ", symbol=" + symbol + ", source=" + source + ", bidCount=" + bidCount
+                + ", offerCount=" + offerCount + ", bidPrice=" + Arrays.toString(bidPrice) + ", bidQty="
+                + Arrays.toString(bidQty) + ", offerPrice=" + Arrays.toString(offerPrice) + ", offerQty="
+                + Arrays.toString(offerQty) + "]";
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/example/feed/RequestReject.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/RequestReject.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.example.feed;
+
+public class RequestReject {
+
+    private long timestamp;
+    private String requestId;
+    private int errorCode;
+    private String errorMessage;
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(final long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(final String requestId) {
+        this.requestId = requestId;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(final int errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(final String msg) {
+        this.errorMessage = msg;
+    }
+
+    @Override
+    public String toString() {
+        return "RequestReject [timestamp=" + timestamp + ", requestId=" + requestId + ", errorCode=" + errorCode
+                + ", errorMessage=" + errorMessage + "]";
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/ws/FeedGatewayException.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/FeedGatewayException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.ws;
+
+public class FeedGatewayException extends Exception {
+
+    private static final long serialVersionUID = -2158080208144828335L;
+
+    public FeedGatewayException(final String msg, final Throwable t) {
+        super(msg, t);
+    }
+
+    public FeedGatewayException(final Throwable t) {
+        super(t);
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/ws/FeedRequestMessageFactory.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/FeedRequestMessageFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.ws;
+
+import java.nio.ByteBuffer;
+
+import org.agrona.concurrent.HighResolutionClock;
+
+import com.google.flatbuffers.FlatBufferBuilder;
+import com.reactivemarkets.encoding.feed.Body;
+import com.reactivemarkets.encoding.feed.FeedRequest;
+import com.reactivemarkets.encoding.feed.Message;
+import com.reactivemarkets.encoding.feed.SubReqType;
+import com.reactivemarkets.platform.fbs.FbsFactory;
+
+public final class FeedRequestMessageFactory {
+
+    private FeedRequestMessageFactory() {
+    }
+
+    public static ByteBuffer newSubscription(final FeedRequestParameters request) {
+        final FlatBufferBuilder builder = FbsFactory.getFbsBuilder();
+
+        final int reqIdOffset = builder.createString(request.getRequestId());
+
+        final String[] markets = request.getMarkets();
+        final int[] marketOffsets = new int[markets.length];
+        for (int i = 0; i < markets.length; i++) {
+            final int marketOffset = builder.createString(markets[i]);
+            marketOffsets[i] = marketOffset;
+        }
+
+        final int marketsOffset = FeedRequest.createMarketsVector(builder, marketOffsets);
+        final int mdrOffset = FeedRequest.createFeedRequest(builder, reqIdOffset, SubReqType.Subscribe,
+                request.getFeedType(), request.getGrouping(), request.getConflation(), request.getDepth(),
+                marketsOffset);
+
+        Message.startMessage(builder);
+        Message.addTts(builder, HighResolutionClock.epochNanos());
+        Message.addBodyType(builder, Body.FeedRequest);
+        Message.addBody(builder, mdrOffset);
+        int message = Message.endMessage(builder);
+        builder.finish(message);
+
+        return ByteBuffer.wrap(builder.sizedByteArray());
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/ws/FeedRequestParameters.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/FeedRequestParameters.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.ws;
+
+import com.reactivemarkets.encoding.feed.Feed;
+
+public class FeedRequestParameters {
+
+    /**
+     * Unique identifier of this request to be referenced on Feed Gateway responses.
+     */
+    private final String requestId;
+    /**
+     * List of markets to subscribe to in the form <instrument>-<venue>. E.g.
+     * BTCUSD-CNB
+     */
+    private final String[] markets;
+    /**
+     * Type of feed for the subscription. Currently only default supported.
+     */
+    private Short feedType = Feed.Default;
+    /**
+     * Depth of the order book. Top of Book = 1.
+     */
+    private Short depth = 10;
+    /**
+     * Conflation time of order book updates in milliseconds.
+     */
+    private int conflation = 1000;
+    /**
+     * Grouping of order book updates in price ticks. E.g. for BTCUSD at 6501.37, 1
+     * would be 6501.37, 10 would be 6501.4, 50 would be 6503.5
+     */
+    private int grouping = 1;
+
+    public FeedRequestParameters(final String requestId, final String... markets) {
+        super();
+        this.requestId = requestId;
+        this.markets = markets;
+    }
+
+    public FeedRequestParameters setFeedType(final Short feedType) {
+        this.feedType = feedType;
+        return this;
+    }
+
+    public FeedRequestParameters setDepth(final Short depth) {
+        this.depth = depth;
+        return this;
+    }
+
+    public FeedRequestParameters setConflation(final int conflation) {
+        this.conflation = conflation;
+        return this;
+    }
+
+    public FeedRequestParameters setGrouping(final int grouping) {
+        this.grouping = grouping;
+        return this;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String[] getMarkets() {
+        return markets;
+    }
+
+    public Short getFeedType() {
+        return feedType;
+    }
+
+    public Short getDepth() {
+        return depth;
+    }
+
+    public int getConflation() {
+        return conflation;
+    }
+
+    public int getGrouping() {
+        return grouping;
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/ws/tyrus/TyrusWebSocketClient.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/tyrus/TyrusWebSocketClient.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.ws.tyrus;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.ClientEndpointConfig.Builder;
+import javax.websocket.ClientEndpointConfig.Configurator;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.DeploymentException;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.reactivemarkets.platform.ws.FeedGatewayException;
+
+/**
+ * TyrusWebSocketClient is a websocket client implementation based on the Tyrus
+ * javax.websocket implementation. This implementation has drawn from examples
+ * in
+ * https://abhirockzz.gitbooks.io/java-websocket-api-handbook/content/Receiving%20Messages.html
+ * <p>
+ * TyrusWebSocketClient are not intended for use by multiple threads and the
+ * connect, close, send and isConnected methods are not thread-safe.
+ */
+public class TyrusWebSocketClient extends Endpoint implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TyrusWebSocketClient.class);
+    private final URI uri;
+    private final String authToken;
+    private final MessageHandler handler;
+    private Session session;
+
+    public TyrusWebSocketClient(final String uri, final String authToken,
+            final MessageHandler.Whole<ByteBuffer> handler) {
+        super();
+        this.uri = URI.create(uri);
+        this.authToken = authToken;
+        this.handler = handler;
+    }
+
+    public void connect() throws FeedGatewayException {
+
+        final WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+        final Builder configBuilder = ClientEndpointConfig.Builder.create();
+        configBuilder.configurator(new Configurator() {
+            public void beforeRequest(final Map<String, List<String>> headers) {
+                headers.put("Authorization", Arrays.asList("Bearer " + authToken));
+            }
+        });
+        final ClientEndpointConfig config = configBuilder.build();
+        try {
+            session = container.connectToServer(this, config, uri);
+        } catch (DeploymentException | IOException e) {
+            throw new FeedGatewayException("Failed to connect to endpoint: " + uri, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (session != null) {
+            try {
+                session.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+
+    @Override
+    public void onOpen(final Session session, final EndpointConfig config) {
+        session.addMessageHandler(handler);
+    }
+
+    @Override
+    public void onClose(final Session session, final CloseReason closeReason) {
+        LOGGER.warn("WebSocket session closed: {}", closeReason.getReasonPhrase());
+    }
+
+    @Override
+    public void onError(final Session session, final Throwable thr) {
+        LOGGER.error("WebSocket session error.", thr);
+    }
+
+    /*
+     * Blocking send of the message
+     */
+    public void send(final ByteBuffer buf) throws FeedGatewayException {
+        try {
+            session.getBasicRemote().sendBinary(buf);
+        } catch (IOException e) {
+            throw new FeedGatewayException(e);
+        }
+    }
+
+    public boolean isConnected() {
+        return session != null && session.isOpen();
+    }
+}

--- a/src/main/java/com/reactivemarkets/platform/ws/tyrus/TyrusWebSocketClientFactory.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/tyrus/TyrusWebSocketClientFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Reactive Markets Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reactivemarkets.platform.ws.tyrus;
+
+import java.nio.ByteBuffer;
+
+import javax.websocket.MessageHandler;
+
+public final class TyrusWebSocketClientFactory {
+
+    private TyrusWebSocketClientFactory() {
+    }
+
+    public static TyrusWebSocketClient newWebSocketClient(final String uri, final String authToken,
+            final MessageHandler.Whole<ByteBuffer> handler) {
+        return new TyrusWebSocketClient(uri, authToken, handler);
+    }
+}


### PR DESCRIPTION
Changes:
- add new Feed flatbuffers to com.reactivemarkets.encoding.feed
- websocket client based on Tyrus library
- example feed gateway L2 subscription

DEV-1822