### PR TITLE
chore: add depth to flatbuffers MD snapshot

### DIFF
--- a/src/main/java/com/reactivemarkets/encoding/feed/FeedRequest.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/FeedRequest.java
@@ -32,9 +32,9 @@ public final class FeedRequest extends Table {
   public ByteBuffer reqIdInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 4, 1); }
   public short subReqType() { int o = __offset(6); return o != 0 ? bb.getShort(o + bb_pos) : 1; }
   public short feedType() { int o = __offset(8); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
-  public int depth() { int o = __offset(10); return o != 0 ? bb.get(o + bb_pos) & 0xFF : 0; }
-  public int grouping() { int o = __offset(12); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
-  public int frequency() { int o = __offset(14); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
+  public int grouping() { int o = __offset(10); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
+  public short depth() { int o = __offset(12); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
+  public short frequency() { int o = __offset(14); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
   public String markets(int j) { int o = __offset(16); return o != 0 ? __string(__vector(o) + j * 4) : null; }
   public int marketsLength() { int o = __offset(16); return o != 0 ? __vector_len(o) : 0; }
 
@@ -42,18 +42,18 @@ public final class FeedRequest extends Table {
       int req_idOffset,
       short sub_req_type,
       short feed_type,
-      int depth,
       int grouping,
-      int frequency,
+      short depth,
+      short frequency,
       int marketsOffset) {
     builder.startObject(7);
     FeedRequest.addMarkets(builder, marketsOffset);
-    FeedRequest.addFrequency(builder, frequency);
     FeedRequest.addReqId(builder, req_idOffset);
+    FeedRequest.addFrequency(builder, frequency);
+    FeedRequest.addDepth(builder, depth);
     FeedRequest.addGrouping(builder, grouping);
     FeedRequest.addFeedType(builder, feed_type);
     FeedRequest.addSubReqType(builder, sub_req_type);
-    FeedRequest.addDepth(builder, depth);
     return FeedRequest.endFeedRequest(builder);
   }
 
@@ -61,9 +61,9 @@ public final class FeedRequest extends Table {
   public static void addReqId(FlatBufferBuilder builder, int reqIdOffset) { builder.addOffset(0, reqIdOffset, 0); }
   public static void addSubReqType(FlatBufferBuilder builder, short subReqType) { builder.addShort(1, subReqType, 1); }
   public static void addFeedType(FlatBufferBuilder builder, short feedType) { builder.addShort(2, feedType, 0); }
-  public static void addDepth(FlatBufferBuilder builder, int depth) { builder.addByte(3, (byte)depth, (byte)0); }
-  public static void addGrouping(FlatBufferBuilder builder, int grouping) { builder.addShort(4, (short)grouping, (short)0); }
-  public static void addFrequency(FlatBufferBuilder builder, int frequency) { builder.addInt(5, frequency, 0); }
+  public static void addGrouping(FlatBufferBuilder builder, int grouping) { builder.addShort(3, (short)grouping, (short)0); }
+  public static void addDepth(FlatBufferBuilder builder, short depth) { builder.addShort(4, depth, 0); }
+  public static void addFrequency(FlatBufferBuilder builder, short frequency) { builder.addShort(5, frequency, 0); }
   public static void addMarkets(FlatBufferBuilder builder, int marketsOffset) { builder.addOffset(6, marketsOffset, 0); }
   public static int createMarketsVector(FlatBufferBuilder builder, int[] data) { builder.startVector(4, data.length, 4); for (int i = data.length - 1; i >= 0; i--) builder.addOffset(data[i]); return builder.endVector(); }
   public static void startMarketsVector(FlatBufferBuilder builder, int numElems) { builder.startVector(4, numElems, 4); }

--- a/src/main/java/com/reactivemarkets/encoding/feed/MDSnapshotL2.java
+++ b/src/main/java/com/reactivemarkets/encoding/feed/MDSnapshotL2.java
@@ -36,13 +36,14 @@ public final class MDSnapshotL2 extends Table {
   public ByteBuffer marketInByteBuffer(ByteBuffer _bb) { return __vector_in_bytebuffer(_bb, 8, 1); }
   public int feedId() { int o = __offset(10); return o != 0 ? bb.getInt(o + bb_pos) : 0; }
   public long id() { int o = __offset(12); return o != 0 ? bb.getLong(o + bb_pos) : 0L; }
-  public int flags() { int o = __offset(14); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
+  public short depth() { int o = __offset(14); return o != 0 ? bb.getShort(o + bb_pos) : 0; }
+  public int flags() { int o = __offset(16); return o != 0 ? bb.getShort(o + bb_pos) & 0xFFFF : 0; }
   public MDLevel2 bidSide(int j) { return bidSide(new MDLevel2(), j); }
-  public MDLevel2 bidSide(MDLevel2 obj, int j) { int o = __offset(16); return o != 0 ? obj.__assign(__vector(o) + j * 16, bb) : null; }
-  public int bidSideLength() { int o = __offset(16); return o != 0 ? __vector_len(o) : 0; }
+  public MDLevel2 bidSide(MDLevel2 obj, int j) { int o = __offset(18); return o != 0 ? obj.__assign(__vector(o) + j * 16, bb) : null; }
+  public int bidSideLength() { int o = __offset(18); return o != 0 ? __vector_len(o) : 0; }
   public MDLevel2 offerSide(int j) { return offerSide(new MDLevel2(), j); }
-  public MDLevel2 offerSide(MDLevel2 obj, int j) { int o = __offset(18); return o != 0 ? obj.__assign(__vector(o) + j * 16, bb) : null; }
-  public int offerSideLength() { int o = __offset(18); return o != 0 ? __vector_len(o) : 0; }
+  public MDLevel2 offerSide(MDLevel2 obj, int j) { int o = __offset(20); return o != 0 ? obj.__assign(__vector(o) + j * 16, bb) : null; }
+  public int offerSideLength() { int o = __offset(20); return o != 0 ? __vector_len(o) : 0; }
 
   public static int createMDSnapshotL2(FlatBufferBuilder builder,
       long source_ts,
@@ -50,10 +51,11 @@ public final class MDSnapshotL2 extends Table {
       int marketOffset,
       int feed_id,
       long id,
+      short depth,
       int flags,
       int bid_sideOffset,
       int offer_sideOffset) {
-    builder.startObject(8);
+    builder.startObject(9);
     MDSnapshotL2.addId(builder, id);
     MDSnapshotL2.addSourceTs(builder, source_ts);
     MDSnapshotL2.addOfferSide(builder, offer_sideOffset);
@@ -62,19 +64,21 @@ public final class MDSnapshotL2 extends Table {
     MDSnapshotL2.addMarket(builder, marketOffset);
     MDSnapshotL2.addSource(builder, sourceOffset);
     MDSnapshotL2.addFlags(builder, flags);
+    MDSnapshotL2.addDepth(builder, depth);
     return MDSnapshotL2.endMDSnapshotL2(builder);
   }
 
-  public static void startMDSnapshotL2(FlatBufferBuilder builder) { builder.startObject(8); }
+  public static void startMDSnapshotL2(FlatBufferBuilder builder) { builder.startObject(9); }
   public static void addSourceTs(FlatBufferBuilder builder, long sourceTs) { builder.addLong(0, sourceTs, 0L); }
   public static void addSource(FlatBufferBuilder builder, int sourceOffset) { builder.addOffset(1, sourceOffset, 0); }
   public static void addMarket(FlatBufferBuilder builder, int marketOffset) { builder.addOffset(2, marketOffset, 0); }
   public static void addFeedId(FlatBufferBuilder builder, int feedId) { builder.addInt(3, feedId, 0); }
   public static void addId(FlatBufferBuilder builder, long id) { builder.addLong(4, id, 0L); }
-  public static void addFlags(FlatBufferBuilder builder, int flags) { builder.addShort(5, (short)flags, (short)0); }
-  public static void addBidSide(FlatBufferBuilder builder, int bidSideOffset) { builder.addOffset(6, bidSideOffset, 0); }
+  public static void addDepth(FlatBufferBuilder builder, short depth) { builder.addShort(5, depth, 0); }
+  public static void addFlags(FlatBufferBuilder builder, int flags) { builder.addShort(6, (short)flags, (short)0); }
+  public static void addBidSide(FlatBufferBuilder builder, int bidSideOffset) { builder.addOffset(7, bidSideOffset, 0); }
   public static void startBidSideVector(FlatBufferBuilder builder, int numElems) { builder.startVector(16, numElems, 8); }
-  public static void addOfferSide(FlatBufferBuilder builder, int offerSideOffset) { builder.addOffset(7, offerSideOffset, 0); }
+  public static void addOfferSide(FlatBufferBuilder builder, int offerSideOffset) { builder.addOffset(8, offerSideOffset, 0); }
   public static void startOfferSideVector(FlatBufferBuilder builder, int numElems) { builder.startVector(16, numElems, 8); }
   public static int endMDSnapshotL2(FlatBufferBuilder builder) {
     int o = builder.endObject();

--- a/src/main/java/com/reactivemarkets/platform/example/feed/FeedMessageHandler.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/FeedMessageHandler.java
@@ -79,6 +79,7 @@ public class FeedMessageHandler implements MessageHandler.Whole<ByteBuffer> {
         final MarketDepth depth = new MarketDepth(bidCount, offerCount);
         depth.setId(ss.id());
         depth.setFeedId(ss.feedId());
+        depth.setDepth(ss.depth());
         depth.setSource(ss.source());
         depth.setFlags(ss.flags());
         depth.setBidCount(ss.bidSideLength());

--- a/src/main/java/com/reactivemarkets/platform/example/feed/MarketDepth.java
+++ b/src/main/java/com/reactivemarkets/platform/example/feed/MarketDepth.java
@@ -22,6 +22,7 @@ public class MarketDepth {
 
     private long id;
     private int feedId;
+    private int depth;
     private long flags;
     private long timestamp;
     private long sourceTimestamp;
@@ -163,12 +164,20 @@ public class MarketDepth {
         this.feedId = feedId;
     }
 
+    public int getDepth() {
+        return depth;
+    }
+
+    public void setDepth(final int depth) {
+        this.depth = depth;
+    }
+
     @Override
     public String toString() {
-        return "MarketDepth [id=" + id + ", feedId=" + feedId + ", flags=" + flags + ", timestamp=" + timestamp
-                + ", sourceTimestamp=" + sourceTimestamp + ", symbol=" + symbol + ", source=" + source + ", bidCount="
-                + bidCount + ", offerCount=" + offerCount + ", bidPrice=" + Arrays.toString(bidPrice) + ", bidQty="
-                + Arrays.toString(bidQty) + ", offerPrice=" + Arrays.toString(offerPrice) + ", offerQty="
+        return "MarketDepth [id=" + id + ", feedId=" + feedId + ", depth=" + depth + ", flags=" + flags + ", timestamp="
+                + timestamp + ", sourceTimestamp=" + sourceTimestamp + ", symbol=" + symbol + ", source=" + source
+                + ", bidCount=" + bidCount + ", offerCount=" + offerCount + ", bidPrice=" + Arrays.toString(bidPrice)
+                + ", bidQty=" + Arrays.toString(bidQty) + ", offerPrice=" + Arrays.toString(offerPrice) + ", offerQty="
                 + Arrays.toString(offerQty) + "]";
     }
 }

--- a/src/main/java/com/reactivemarkets/platform/ws/FeedRequestMessageFactory.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/FeedRequestMessageFactory.java
@@ -46,7 +46,7 @@ public final class FeedRequestMessageFactory {
 
         final int marketsOffset = FeedRequest.createMarketsVector(builder, marketOffsets);
         final int feedRequestOffset = FeedRequest.createFeedRequest(builder, reqIdOffset, SubReqType.Subscribe,
-                request.getFeedType(), request.getDepth(), request.getGrouping(), request.getFrequency(),
+                request.getFeedType(), request.getGrouping(), request.getDepth(), request.getFrequency(),
                 marketsOffset);
 
         Message.startMessage(builder);

--- a/src/main/java/com/reactivemarkets/platform/ws/FeedRequestParameters.java
+++ b/src/main/java/com/reactivemarkets/platform/ws/FeedRequestParameters.java
@@ -32,7 +32,7 @@ public class FeedRequestParameters {
     /**
      * Type of feed for the subscription. Currently only default supported.
      */
-    private byte feedType = FeedType.Default;
+    private short feedType = FeedType.Default;
     /**
      * Depth of the order book. Top of Book = 1.
      */
@@ -40,7 +40,7 @@ public class FeedRequestParameters {
     /**
      * Conflation time of order book updates in milliseconds.
      */
-    private int frequency = 1000;
+    private short frequency = 1000;
     /**
      * Grouping of order book updates in price ticks. E.g. for BTCUSD at 6501.37, 1
      * would be 6501.37, 10 would be 6501.4, 50 would be 6503.5
@@ -63,7 +63,7 @@ public class FeedRequestParameters {
         return this;
     }
 
-    public FeedRequestParameters setFrequency(final int frequency) {
+    public FeedRequestParameters setFrequency(final short frequency) {
         this.frequency = frequency;
         return this;
     }
@@ -81,7 +81,7 @@ public class FeedRequestParameters {
         return markets;
     }
 
-    public byte getFeedType() {
+    public short getFeedType() {
         return feedType;
     }
 
@@ -89,7 +89,7 @@ public class FeedRequestParameters {
         return depth;
     }
 
-    public int getFrequency() {
+    public short getFrequency() {
         return frequency;
     }
 


### PR DESCRIPTION
Changes:
- upgraded to latest flatbuffers schema
- added depth field to the level 2 MarketDepth snapshot
- aligned Feed Request data types to flatbuffers schema